### PR TITLE
Add public visibility to LinkedInOAuthServiceImpl

### DIFF
--- a/linkedin-j/core/src/main/java/com/google/code/linkedinapi/client/oauth/LinkedInOAuthServiceImpl.java
+++ b/linkedin-j/core/src/main/java/com/google/code/linkedinapi/client/oauth/LinkedInOAuthServiceImpl.java
@@ -43,7 +43,7 @@ import com.google.code.linkedinapi.client.constant.LinkedInApiUrls;
  * @author Nabeel Mukhtar
  *
  */
-class LinkedInOAuthServiceImpl implements LinkedInOAuthService {
+public class LinkedInOAuthServiceImpl implements LinkedInOAuthService {
 
     /** Field description */
     private final LinkedInApiConsumer apiConsumer;
@@ -60,7 +60,7 @@ class LinkedInOAuthServiceImpl implements LinkedInOAuthService {
      *
      * @param apiConsumer
      */
-    LinkedInOAuthServiceImpl(LinkedInApiConsumer apiConsumer) {
+    public LinkedInOAuthServiceImpl(LinkedInApiConsumer apiConsumer) {
     	requestHeaders = new HashMap<String, String>();
     	this.apiConsumer = apiConsumer;
     }


### PR DESCRIPTION
This correction is needed to avoir the error
java.lang.NoSuchMethodError:
oauth.signpost.OAuthProvider.retrieveRequestToken(Loauth/signpost/OAuthConsumer;Ljava/lang/String;)Ljava/lang/String;